### PR TITLE
fix demoting into a inherited groups, using PEX

### DIFF
--- a/src/org/ruhlendavis/mc/communitybridge/PermissionHandlerPermissionsEx.java
+++ b/src/org/ruhlendavis/mc/communitybridge/PermissionHandlerPermissionsEx.java
@@ -49,7 +49,7 @@ public class PermissionHandlerPermissionsEx implements PermissionHandler
 	{
 		try
 		{
-			return PermissionsEx.getUser(playerName).inGroup(groupName);
+			return PermissionsEx.getUser(playerName).inGroup(groupName, false);
 		}
 		catch (Error e)
 		{


### PR DESCRIPTION
inGroup(string) checks for all groups, also inherited ones.
that made demoting impossible.

adding the "false" solves this problem.

more info here:
https://github.com/PEXPlugins/PermissionsEx/wiki/Native-API-example#wiki-pex-api-pu-ingroup
